### PR TITLE
Allow communication between nested fragments

### DIFF
--- a/src/event/message-event-bus.ts
+++ b/src/event/message-event-bus.ts
@@ -13,9 +13,9 @@ export class MessageEventBus implements IEventBus {
 
   /**
    * A window can only bind listeners to itself but post to other windows.
-   * E.g. Host -> listen on window, post on iframe.contentWindow | Fragment -> listen on window, post of window.top
+   * E.g. Host -> listen on window, post on iframe.contentWindow | Fragment -> listen on window, post of window.parent
    * @param readWindow Will be always window
-   * @param writeWindow Will be iframe.contentWindow or window.top
+   * @param writeWindow Will be iframe.contentWindow or window.parent
    * @param fragmentId Used to identify identify fragments on host window
    */
   constructor(public fragmentId: number, private readWindow: Window, private writeWindow: WindowProxy | null) {

--- a/src/fragment/framed/framed-fragment.ts
+++ b/src/fragment/framed/framed-fragment.ts
@@ -6,12 +6,12 @@ export const FramedFragment: IFragmentStatic = class extends EventAware implemen
   private interval?: number;
 
   static isFragment(): boolean {
-    return window.location !== window.top.location && !isNaN(parseInt(window.name, 10));
+    return window.location !== window.parent.location && !isNaN(parseInt(window.name, 10));
   }
 
   public async initialize(defaultOptions: unknown, initCb: (config: unknown) => void | Promise<void>): Promise<void> {
     const fragmentId = parseInt(window.name, 10);
-    this.event = new MessageEventBus(fragmentId, window, window.top);
+    this.event = new MessageEventBus(fragmentId, window, window.parent);
 
     this.event.dispatchEvent('ready-for-init', defaultOptions || {});
 


### PR DESCRIPTION
Use window.parent when posting from fragment to allow fragment to also be a host